### PR TITLE
fix: attribute latest is deprecated

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ resource "docker_image" "nginx" {
 }
 
 resource "docker_container" "nginx" {
-  image = docker_image.nginx.latest
+  image = docker_image.nginx.repo_digest
   name  = "hello-terraform"
   ports {
     internal = 80

--- a/nginx/main.tf
+++ b/nginx/main.tf
@@ -4,7 +4,7 @@ resource "docker_image" "nginx" {
 }
 
 resource "docker_container" "nginx" {
-  image = docker_image.nginx.latest
+  image = docker_image.nginx.repo_digest
   name  = var.container_name
   ports {
     internal = 80

--- a/nginx/versions.tf
+++ b/nginx/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     docker = {
       source = "kreuzwerker/docker"
-      version = "~> 2.16.0"
+      version = "3.0.2"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     docker = {
       source = "kreuzwerker/docker"
-      version = "~> 2.16.0"
+      version = "3.0.2"
     }
 
     random = {


### PR DESCRIPTION
These changes resolves #2 by doing the following:

- migrating the `latest` tag to `repo_digest`
- changing the kreuzwerker/docker provide version from `~> 2.16.0 `to `3.0.2`

Signed-off by Gulcan Topcu <denizkavuk86@gmail.com>