### PR TITLE
update to latest provider versions

### DIFF
--- a/terraform.tf
+++ b/terraform.tf
@@ -6,11 +6,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.7.0"
+      version = "5.43.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = "3.0.1"
+      version = "3.6.0"
     }
   }
   /* Uncomment this block to use Terraform Cloud for this tutorial


### PR DESCRIPTION
Updating versions to the latest due to testing on Mac M3 didn't work:
```bash
 Error: Incompatible provider version
│ 
│ Provider registry.terraform.io/hashicorp/random v3.0.1 does not have a package available for your current platform, darwin_arm64.
```